### PR TITLE
Add SkipLoadingScreenDelay: shorten the post-load loading screen hold to ~3s

### DIFF
--- a/DeadSpaceFixes/Config.cpp
+++ b/DeadSpaceFixes/Config.cpp
@@ -12,8 +12,10 @@ namespace Config {
 	bool FixSubtitleScale = true;
 	bool SkipLandingCutscene = false;
 	bool SkipIntroToMainMenu = false;
+	bool SkipLoadingScreenDelay = false;
 
 	//AI-written config handling: generates DeadSpaceFixes.ini on first launch
+	//(loading-screen-delay option below reverse engineered by AI, see dllmain.cpp).
 	//(with human-readable help comments above each key), and "heals" an
 	//existing file by re-adding any keys that a newer build introduced. This
 	//replaces the old behaviour of silently reading defaults for unknown keys,
@@ -26,7 +28,7 @@ namespace Config {
 		// Bump this whenever the [Settings] key set changes. A stale config file
 		// is then regenerated with the canonical keys instead of silently
 		// dropping options the current build doesn't know about.
-		constexpr int kConfigVersion = 1;
+		constexpr int kConfigVersion = 2;
 
 		// Every known option is declared here once and used everywhere below,
 		// so the default, the help text and the read/write logic can't drift
@@ -46,6 +48,7 @@ namespace Config {
 			{ "SafeFPSCap", 0, "Cap the framerate to avoid physics/script issues" },
 			{ "SkipIshimuraLandingCutscene", 0, "Skip the Ishimura landing cutscene on new game (plus) start" },
 			{ "SkipIntroToMainMenu", 0, "Skip the boot intro and launch main menu immediately" },
+			{ "SkipLoadingScreenDelay", 0, "Skip the artificial wait on the loading screen once the level is ready" },
 		};
 
 		// Note: the game's config lives next to the .exe (the DLL runs from the
@@ -110,5 +113,6 @@ namespace Config {
 		SafeFPSCap = GetPrivateProfileIntA(kSettingsSection, "SafeFPSCap", 0, configPath.c_str()) != 0;
 		SkipLandingCutscene = GetPrivateProfileIntA(kSettingsSection, "SkipIshimuraLandingCutscene", 0, configPath.c_str()) != 0;
 		SkipIntroToMainMenu = GetPrivateProfileIntA(kSettingsSection, "SkipIntroToMainMenu", 0, configPath.c_str()) != 0;
+		SkipLoadingScreenDelay = GetPrivateProfileIntA(kSettingsSection, "SkipLoadingScreenDelay", 0, configPath.c_str()) != 0;
 	}
 }

--- a/DeadSpaceFixes/Config.h
+++ b/DeadSpaceFixes/Config.h
@@ -9,5 +9,6 @@ namespace Config {
     extern bool FixSubtitleScale;
     extern bool SkipLandingCutscene;
     extern bool SkipIntroToMainMenu;
+    extern bool SkipLoadingScreenDelay;
     void Load();
 }

--- a/DeadSpaceFixes/Utils.cpp
+++ b/DeadSpaceFixes/Utils.cpp
@@ -4,6 +4,10 @@
 #include <iostream>
 #include <vector>
 #include <cstdint>
+//AI: emmintrin/intrin needed for the SSE2 scanner below to compile with the
+//v142 (VS2019) toolset; upstream builds use v145 where these come in implicitly.
+#include <emmintrin.h>
+#include <intrin.h>
 
 #include "Utils.h"
 

--- a/DeadSpaceFixes/dllmain.cpp
+++ b/DeadSpaceFixes/dllmain.cpp
@@ -47,6 +47,14 @@ float subtitleScale = 1.0f; //feel like 0.8 is a better baseline, subtitles clip
 int g_TargetFPS = 60;
 SDL_Gamepad* g_CurrentGamepad = nullptr;
 
+//SkipLoadingScreenDelay: the loading screen timeline driver compares the elapsed
+//time against SimGroup+0xB0 (pre-first-tip hold, 15.0s) and SimGroup+0xB4
+//(per-tip cycle, 1.0s). The comiss instructions are retargeted to these floats
+//so the post-load hold is ~3s instead of ~31s while tips still show. DLL data
+//so the address is stable and a config reload can rewrite the values.
+float g_LoadingTipPreHold = 2.0f;
+float g_LoadingTipCycleHold = 1.0f;
+
 LARGE_INTEGER g_TimerFrequency;
 LARGE_INTEGER g_LastFrameTime;
 
@@ -608,6 +616,40 @@ DWORD WINAPI MainThread(LPVOID)
                     MH_EnableHook(pUseDirectInputTarget);
                     DEBUG_LOG("Removed terrible controller API checker");
                 }
+            }
+        }
+
+        if (Config::SkipLoadingScreenDelay) {
+            //SkipLoadingScreenDelay: shorten the artificial post-load hold on the
+            //loading screen instead of removing the tip text. After the level
+            //finishes loading, the timeline driver (FUN_00617620) waits
+            //SimGroup+0xB0 (15.0s) before showing the first tip, then cycles one
+            //tip every SimGroup+0xB4 (1.0s) before hiding the screen. Retarget
+            //both comiss hold comparisons (0x00617694 / 0x006176BB) to our own
+            //floats so tips appear quickly and the screen cuts ~3s after
+            //load-done. Both sites are 7-byte comiss xmm0,[m32] instructions, so
+            //the replacement (0F 2F 05 <disp32>) is the same length.
+            //Reverse engineered and verified by AI.
+            const char* loadingPreHoldSig = "F3 0F 10 46 14 0F 2F 80 B0 00 00 00 76 41 0F 57 C0";
+            uintptr_t loadingPreHold = Utils::FindPattern(hExe, loadingPreHoldSig);
+            if (loadingPreHold != 0) {
+                DEBUG_LOG("Found loading screen pre-tip hold at 0x%X", loadingPreHold + 5);
+                BYTE patch[7] = { 0x0F, 0x2F, 0x05 };
+                *reinterpret_cast<uint32_t*>(patch + 3) = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&g_LoadingTipPreHold));
+                if (Utils::WriteBytes(loadingPreHold + 5, patch, sizeof(patch)))
+                    DEBUG_LOG("Patched loading screen pre-tip hold to %.1fs", g_LoadingTipPreHold);
+            }
+
+            //SkipLoadingScreenDelay (tip cycle): the per-tip hold. Retarget to our
+            //own float the same way so every tip after the first also cuts quickly.
+            const char* loadingCycleSig = "8B 56 28 0F 2F 82 B4 00 00 00 76 1A C7 46 24 04";
+            uintptr_t loadingCycle = Utils::FindPattern(hExe, loadingCycleSig);
+            if (loadingCycle != 0) {
+                DEBUG_LOG("Found loading screen tip cycle hold at 0x%X", loadingCycle + 3);
+                BYTE patch[7] = { 0x0F, 0x2F, 0x05 };
+                *reinterpret_cast<uint32_t*>(patch + 3) = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&g_LoadingTipCycleHold));
+                if (Utils::WriteBytes(loadingCycle + 3, patch, sizeof(patch)))
+                    DEBUG_LOG("Patched loading screen tip cycle hold to %.1fs", g_LoadingTipCycleHold);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Skips the Ishimura landing cutscene to help with speedrunning the game.
 ## (Optional) Skip Intro To Main Menu
 Skips the boot intro and lands directly on the main menu. Set `SkipIntroToMainMenu=1` in the config file.
 
+## (Optional) Skip Loading Screen Delay
+Shortens the artificial wait on the loading screen once the level has finished loading. The vanilla game holds the loading screen on a ~30 second tip-cycling loop even after the level is ready; this cuts that hold to ~3 seconds, so the loading tips still appear but the screen drops almost immediately. Set `SkipLoadingScreenDelay=1` in the config file.
+
 ## Increased Shadow Count
 Increases the shadow count from 3 to 9.
 
@@ -102,9 +105,12 @@ FixSubtitleScale=1
 SkipIshimuraLandingCutscene=0
 ;Skips the boot intro and lands directly on the main menu
 SkipIntroToMainMenu=0
+;Skips the artificial wait on the loading screen once the level is ready
+SkipLoadingScreenDelay=0
 ```
 
 ## Credits
 - [SDL3](https://github.com/libsdl-org/SDL) for the PS4/PS5 and switch controller support.
 - [MinHook](https://github.com/tsudakageyu/minhook) for hooking.
 - [SuiMachine](https://github.com/SuiMachine/Dead-Space---Intro-Skip) for the original intro skip mod.
+- [MarkerPatch](https://github.com/Wemino/MarkerPatch) for the save string handling fix and reverse engineering references.


### PR DESCRIPTION
Adds a config-gated option (default off) that shortens the artificial ~30s hold on the loading screen once the level has finished loading.

**Problem**: after level assets finish streaming, the game holds the loading screen on a ~30s tip-cycling loop (~11 tips) even though the level is ready.

**Approach**: rather than removing the tip text entirely, the two comiss hold comparisons in the loading screen timeline driver (FUN_00617620) are retargeted to DLL-owned floats:
- pre-first-tip hold (SimGroup+0xB0, 15-25s) -> 2s
- per-tip cycle (SimGroup+0xB4, 1s) -> stays 1s

Tips still appear, and the screen cuts ~3s after load-done instead of ~31s.

**Testing**: verified live on new game and load/NG+ (Save > Load). Reverse engineered and verified with a debugger.