### PR TITLE
Add SkipLoreVideos option: make in-game lore videos skippable with F

### DIFF
--- a/DeadSpaceFixes/Config.cpp
+++ b/DeadSpaceFixes/Config.cpp
@@ -18,6 +18,7 @@ namespace Config {
 		bool Telemetry = true;
 		bool IntroCutscene = false;
 		bool MainIntro = false;
+		bool SkipVideos = false;
 	}
 
 	namespace Features {
@@ -71,6 +72,7 @@ namespace Config {
 			{ kPatchesSection, "RemoveTelemetry", 1, "Disable the game's telemetry/data collection" },
 			{ kPatchesSection, "SkipIshimuraLandingCutscene", 0, "Skip the Ishimura landing cutscene on new game (plus) start" },
 			{ kPatchesSection, "SkipIntroToMainMenu", 0, "Skip the boot intro and launch main menu immediately" },
+			{ kPatchesSection, "SkipLoreVideos", 0, "Make newly-triggered lore/vidlog videos skippable with F" },
 			{ kFeaturesSection, "SafeFPSCap", 0, "Cap the framerate to avoid physics/script issues" },
 		};
 
@@ -265,6 +267,7 @@ namespace Config {
 		Patches::Telemetry = read(kPatchesSection, "RemoveTelemetry", 1);
 		Patches::IntroCutscene = read(kPatchesSection, "SkipIshimuraLandingCutscene", 0);
 		Patches::MainIntro = read(kPatchesSection, "SkipIntroToMainMenu", 0);
+		Patches::SkipVideos = read(kPatchesSection, "SkipLoreVideos", 0);
 		Features::FrameRateCap = read(kFeaturesSection, "SafeFPSCap", 0);
 	}
 }

--- a/DeadSpaceFixes/Config.h
+++ b/DeadSpaceFixes/Config.h
@@ -15,6 +15,7 @@ namespace Config {
 		extern bool Telemetry;         // RemoveTelemetry
 		extern bool IntroCutscene;     // SkipIshimuraLandingCutscene
 		extern bool MainIntro;         // SkipIntroToMainMenu
+		extern bool SkipVideos;        // SkipLoreVideos
 	}
 
 	namespace Features {

--- a/DeadSpaceFixes/DeadSpaceFixes.vcxproj
+++ b/DeadSpaceFixes/DeadSpaceFixes.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="include\MinHook\hook.c" />
     <ClCompile Include="include\MinHook\trampoline.c" />
     <ClCompile Include="Patches\Gameplay\IntroCutscene.cpp" />
+    <ClCompile Include="Patches\Gameplay\SkipVideos.cpp" />
     <ClCompile Include="Patches\System\BorderlessWindow.cpp" />
     <ClCompile Include="Patches\System\Telemetry.cpp" />
     <ClCompile Include="Patches\UI\MainIntro.cpp" />

--- a/DeadSpaceFixes/DeadSpaceFixes.vcxproj.filters
+++ b/DeadSpaceFixes/DeadSpaceFixes.vcxproj.filters
@@ -134,6 +134,9 @@
     <ClCompile Include="Patches\Gameplay\IntroCutscene.cpp">
       <Filter>Source Files\Patches</Filter>
     </ClCompile>
+    <ClCompile Include="Patches\Gameplay\SkipVideos.cpp">
+      <Filter>Source Files\Patches</Filter>
+    </ClCompile>
     <ClCompile Include="Patches\UI\MainIntro.cpp">
       <Filter>Source Files\Patches</Filter>
     </ClCompile>

--- a/DeadSpaceFixes/Patches/Gameplay/SkipVideos.cpp
+++ b/DeadSpaceFixes/Patches/Gameplay/SkipVideos.cpp
@@ -1,0 +1,42 @@
+#include "common.h"
+#include "Utils.h"
+
+namespace Patches {
+
+	namespace Gameplay {
+
+		namespace SkipVideos {
+
+			//Makes newly-triggered in-game videos (lore / vidlog) cancellable with
+			//F, like optional item videos and database replays already are.
+			//
+			//The shared video skip gate (sub_587210) only refuses to cancel a
+			//video when a "is skipping allowed?" check fails. New lore videos set
+			//one of two of these checks — the block byte +0x275, or the +0x4C bit
+			//1 flag (different videos/triggers set different ones). NOPing those
+			//two jne's makes the normal path always pass when F is pressed; the
+			//force-skip re-check then only *grants* a second chance and can never
+			//revoke it, so it and the locked check can stay untouched. The F-input
+			//check is left alone, so videos are still only cancelled on F.
+			void Apply(HMODULE hExe)
+			{
+				//Entry of sub_587210 (the shared video skip gate).
+				const char* gateSig = "83 EC 0C 55 8B 6C 24 14 8B 8D 94 02 00 00 32 C0 85 C9 0F 84 ?? ?? ?? ??";
+				uintptr_t gate = Utils::FindPattern(hExe, gateSig);
+				if (gate == 0) {
+					LOG_WARN("[Patches/Gameplay/SkipVideos]", "Video skip gate signature not found");
+					return;
+				}
+
+				//gate+0x56: jne after "block byte +0x275 == 0".
+				//gate+0x6B: jne after "+0x4C bit 1" test.
+				BYTE nop[2] = { 0x90, 0x90 };
+				if (Utils::WriteBytes(gate + 0x56, nop, 2) &&
+				    Utils::WriteBytes(gate + 0x6B, nop, 2))
+					LOG_INFO("[Patches/Gameplay/SkipVideos]", "New in-game videos are now skippable (press F to cancel)");
+				else
+					LOG_WARN("[Patches/Gameplay/SkipVideos]", "Failed to patch the video skip gate");
+			}
+		}
+	}
+}

--- a/DeadSpaceFixes/Patches/Patches.h
+++ b/DeadSpaceFixes/Patches/Patches.h
@@ -8,6 +8,9 @@ namespace Patches {
 		namespace IntroCutscene {
 			void Apply(HMODULE hExe);
 		}
+		namespace SkipVideos {
+			void Apply(HMODULE hExe);
+		}
 	}
 
 	namespace UI {

--- a/DeadSpaceFixes/dllmain.cpp
+++ b/DeadSpaceFixes/dllmain.cpp
@@ -31,6 +31,7 @@ namespace {
 			{ "Fixes/Graphics/SubtitleScale",    []() { return Config::Fixes::SubtitleScale; },      [hExe]() { Fixes::Graphics::SubtitleScale::Apply(hExe); } },
 			{ "Patches/UI/VersionString",        []() { return true; },                             [hExe]() { Patches::UI::VersionString::Apply(hExe); } },
 			{ "Patches/Gameplay/IntroCutscene",  []() { return Config::Patches::IntroCutscene; },    [hExe]() { Patches::Gameplay::IntroCutscene::Apply(hExe); } },
+			{ "Patches/Gameplay/SkipVideos",     []() { return Config::Patches::SkipVideos; },       [hExe]() { Patches::Gameplay::SkipVideos::Apply(hExe); } },
 			{ "Patches/UI/MainIntro",            []() { return Config::Patches::MainIntro; },        [hExe]() { Patches::UI::MainIntro::Apply(hExe); } },
 			{ "Fixes/Save/SafeStringHandling",   []() { return true; },                             [hExe]() { Fixes::Save::SafeStringHandling::Apply(hExe); } },
 			{ "Fixes/Input/LegacyDirectInput",   []() { return Config::Fixes::LegacyDirectInput; },  [hExe]() { Fixes::Input::LegacyDirectInput::Apply(hExe); } },


### PR DESCRIPTION
Makes newly-triggered in-game videos (lore / vidlog) cancellable with F, like optional item videos and database replays already are.

### Problem
The game's shared video-skip gate (\sub_587210\) only allows cancelling a video with F when its internal checks pass. Newly-triggered lore videos set one of two of these checks, so they could never be skipped.

### Fix
A tiny binary patch on the gate: NOP the two \jne\ branches that gate the skip on the block-byte (\+0x275\) and the \+0x4C\ bit-1 flag. The F-input check is untouched, so videos are still only cancelled on F.

### Config
New [Patches] SkipLoreVideos option (default off).